### PR TITLE
Header home and menu titles made configurable from data/globalheader.yml

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,9 +3,11 @@
     <h1>{{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{else}}{{ .Site.Title }}{{end}}</h1>
     <nav id="nav">
         <ul>
-            <li><a href="{{ .Site.BaseURL }}">Home</a></li>
+            {{ $home := .Site.Data.globalheader.home }}
+            <li><a href="{{ .Site.BaseURL }}">{{ $home.title }}</a></li>
             <li>
-                <a href="#" class="icon solid fa-angle-down">Layouts</a>
+                {{ $menu := .Site.Data.globalheader.menu }}
+                <a href="#" class="icon solid fa-angle-down">{{ $menu.title }}</a>
                 <ul>
                     {{- range .Site.Menus.main -}}
                         {{- if .HasChildren -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,13 +1,10 @@
 <!-- Header -->
 <header id="header" {{- if .IsHome -}}class="alt"{{- end -}}>
-    <h1>{{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{else}}{{ .Site.Title }}{{end}}</h1>
+    <h1><a href="{{ .Site.BaseURL }}">{{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{else}}{{ .Site.Title }}{{end}}</a></h1>
     <nav id="nav">
         <ul>
-            {{ $home := .Site.Data.globalheader.home }}
-            <li><a href="{{ .Site.BaseURL }}">{{ $home.title }}</a></li>
             <li>
-                {{ $menu := .Site.Data.globalheader.menu }}
-                <a href="#" class="icon solid fa-angle-down">{{ $menu.title }}</a>
+                <a href="#" class="icon solid fa-bars"></a>
                 <ul>
                     {{- range .Site.Menus.main -}}
                         {{- if .HasChildren -}}


### PR DESCRIPTION
Oddly, the home and menu titles were hard-coded in header.html.

This PR makes them configurable via data/globalheader.yml.